### PR TITLE
Build go version when `noasm` build tag provided on amd64

### DIFF
--- a/metro64.go
+++ b/metro64.go
@@ -1,4 +1,4 @@
-// +build !amd64
+// +build noasm !amd64
 
 package metro
 

--- a/metro_stub.go
+++ b/metro_stub.go
@@ -1,5 +1,4 @@
-// +build amd64
-// +build !noasm
+// +build !noasm,amd64
 
 package metro
 


### PR DESCRIPTION
Without this, it is impossible to build this library on amd64 with
`noasm`.